### PR TITLE
First stab at API

### DIFF
--- a/example.c
+++ b/example.c
@@ -1,0 +1,41 @@
+#include "zend_instrument.h"
+
+void example(void) {
+	zend_instrument noop = {
+		.begin = NULL,
+		.end = NULL,
+		.exception = NULL,
+		.ext = NULL,
+	};
+
+	// instrument SplFixedArray::toArray
+	zend_instrument_register(
+		(zend_instrument_target) {
+			.type = ZEND_INSTRUMENT_CALL,
+			.classname = "SplFixedArray",
+			.funcname = "toArray",
+		},
+		noop);
+
+	// instrument require/include/eval
+	zend_instrument_register(
+		(zend_instrument_target) {
+			.type = ZEND_INSTRUMENT_OPCODE,
+			.opcode = ZEND_INCLUDE_OR_EVAL
+		},
+		noop);
+
+	// instrument PDOStatement::execute
+	zend_instrument_register(
+		(zend_instrument_target) {
+			.type = ZEND_INSTRUMENT_CALL,
+			.classname = "SplFixedArray",
+			.funcname = "toArray",
+		},
+		(zend_instrument) {
+			.begin = NULL,
+			.end = NULL,
+			.exception = NULL,
+			.ext = NULL,
+		});
+}

--- a/zend_instrument.h
+++ b/zend_instrument.h
@@ -1,0 +1,36 @@
+#ifndef ZEND_INSTRUMENT_H
+#define ZEND_INSTRUMENT_H
+
+#include <Zend/zend.h>
+#include <Zend/zend_vm_opcodes.h>
+
+typedef void (*zend_instrument_fn)(zend_execute_data *, zval *, void *ext);
+
+struct zend_instrument {
+	zend_instrument_fn begin;
+	zend_instrument_fn end;
+	zend_instrument_fn exception;
+	void *ext;
+};
+typedef struct zend_instrument zend_instrument;
+
+struct zend_instrument_target {
+	enum { ZEND_INSTRUMENT_OPCODE, ZEND_INSTRUMENT_CALL } type;
+	union {
+		zend_uchar opcode;
+		struct {
+			/* 1. Use only funcname to trace a function
+			 * 2. Use both for a method
+			 * 3. Use neither for all function calls
+			 */
+			const char *classname;
+			const char *funcname;
+		};
+	};
+};
+typedef struct zend_instrument_target zend_instrument_target;
+
+_Bool zend_instrument_register(zend_instrument_target, zend_instrument);
+_Bool zend_instrument_unregister(zend_instrument_target, zend_instrument);
+
+#endif


### PR DESCRIPTION
I couldn't get this off my mind and I had a bit of time, so I took a stab at it. Had a few important thoughts:
 
  - For opcodes, do we think the engine can feasibly call the instrument's `.exception` handler before heading down the exception path?
  - For instrumenting methods we probably need to design in some way to manage inheritance. For instance, if I instrument "BaseClass::foo" and then "Inheritor::foo" overrides it, should we instrument the base or the inheritor? Not sure where to fit it in the API yet.
    - In this vein, it would be nice to be able to instrument interface implementors without knowing their names. 

Lower priority thoughts:
  - For unregistering something, we can return something richer than a bool, such as:
    - We didn't find such a target.
    - We found the target, but not your instrument.
    - We found the target and your instrument, but couldn't unregister it at this time.
